### PR TITLE
Avoid correcting quoted mistakes

### DIFF
--- a/main.py
+++ b/main.py
@@ -262,15 +262,13 @@ try:
                     # Continue with check if all conditions met
                     if not any([is_bot(comment), comment.saved, user_stopped]):
                         for mistake in mistakes:
-                            correction = mistake.check(comment.body.lower())
+                            # Strip quotes from the comment before checking it
+                            comment_without_quotes = "\n".join(line for line in comment.body.split("\n") if line[0] != ">").lower()
+                            correction = mistake.check(comment_without_quotes)
 
                             if correction:
                                 explanation = mistake.explain()
-                                context = mistake.find_context(comment.body.lower())
-
-                                # Skip quoted mistakes
-                                if ">" in context:
-                                    continue
+                                context = mistake.find_context(comment_without_quotes)
 
                                 try:
                                     send_correction(comment=comment, correction=correction, explanation=explanation,


### PR DESCRIPTION
Issue encountered [here](https://www.reddit.com/r/facepalm/comments/12la9tf/the_story_of_the_brazilian_priest_who_tied/jg744j3/?context=1). Instead of complaining in a PM I figured it seemed an easy fix.

The check that was previously in place was not working in some cases because it was only checking the context of this mistake- if this did not contain the `>`, the mistake was corrected as you can see in the above example.

I don't see any unit tests so overall bot behavior is untested, but I tested the string manipulation in the REPL and it works as expected, removing every line beginning with `>`. Running this through the mistake checker and context finder seems sufficient.