### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
       - name: checkout repo content
-        uses: actions/checkout@v3.5.3 # checkout the repository content to GitHub runner
+        uses: actions/checkout@v4.1.0 # checkout the repository content to GitHub runner
 
       - name: setup python
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: '3.10' # install the python version needed
 
@@ -37,7 +37,7 @@ jobs:
           git diff-index --quiet HEAD || (git commit -a -m "Updated runs, bans, and counter" --allow-empty)
 
       - name: push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.4.0
+      - uses: actions/checkout@v4.1.0
         with:
           # Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.1](https://github.com/actions/setup-python/releases/tag/v4.7.1)** on 2023-10-02T10:59:39Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v0.8.0](https://github.com/ad-m/github-push-action/releases/tag/v0.8.0)** on 2023-10-10T04:56:58Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
