### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: checkout repo content
-        uses: actions/checkout@v4.1.0 # checkout the repository content to GitHub runner
+        uses: actions/checkout@v4.1.1 # checkout the repository content to GitHub runner
 
       - name: setup python
         uses: actions/setup-python@v4.7.1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           # Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
